### PR TITLE
Fixed some issues found by PVS-Studio static code analyser

### DIFF
--- a/SrcPony/at17xxx.cpp
+++ b/SrcPony/at17xxx.cpp
@@ -304,11 +304,6 @@ int At17xxx::Verify(int type)
 
 	unsigned char *localbuf = new unsigned char[readpage_size];
 
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
-
 	GetBus()->ReadStart();
 
 	rval = 1;               //true

--- a/SrcPony/at250xx.cpp
+++ b/SrcPony/at250xx.cpp
@@ -125,13 +125,7 @@ int At250xx::Verify(int type)
 	}
 
 	int size = GetNoOfBank() * GetBankSize();
-	unsigned char *localbuf;
-	localbuf = new unsigned char[size];
-
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
+    unsigned char *localbuf = new unsigned char[size];
 
 	int rval = 1;
 

--- a/SrcPony/at89sbus.cpp
+++ b/SrcPony/at89sbus.cpp
@@ -66,8 +66,11 @@ At89sBus::At89sBus(BusInterface *ptr)
 	  ReadLockBits0(0x24), ReadLockBits1(0x00),
 	  WriteLockBits0(0xAC), WriteLockBits1(0xE0), OldWriteLockBits1(0x07),
 	  ReadSignatureByte(0x28),
-	  twd_erase(50),
-	  oldmode(true)
+      enable_datapage_polling(false),
+      enable_progpage_polling(false),
+      twd_erase(50),
+      twd_prog(20),
+      oldmode(true)
 {
 }
 

--- a/SrcPony/at89sxx.cpp
+++ b/SrcPony/at89sxx.cpp
@@ -277,13 +277,7 @@ int At89sxx::Verify(int type)
 
 	if (GetSize() >= GetSplitted())
 	{
-		unsigned char *localbuf;
-		localbuf = new unsigned char[GetSize()];
-
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
+        unsigned char *localbuf = new unsigned char[GetSize()];
 
 		int v_data = OK, v_prog = OK, v_config = OK;
 

--- a/SrcPony/at90sxx.cpp
+++ b/SrcPony/at90sxx.cpp
@@ -481,13 +481,7 @@ int At90sxx::Verify(int type)
 
 	if (GetSize() >= GetSplitted())
 	{
-		unsigned char *localbuf;
-		localbuf = new unsigned char[GetSize()];
-
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
+        unsigned char *localbuf = new unsigned char[GetSize()];
 
 		int v_data = OK, v_prog = OK, v_config = OK;
 

--- a/SrcPony/at93cbus.h
+++ b/SrcPony/at93cbus.h
@@ -52,9 +52,9 @@ class At93cBus : public MicroWireBus
 
 	int Erase(int type = 0);
 
-	int CalcAddressSize(int mem_size) const
+    int CalcAddressSize(int mem_size) const override
 	{
-		return MicroWireBus::CalcAddressSize(mem_size, organization);
+        return MicroWireBus::CalcAddressSize(mem_size);
 	}
 
 

--- a/SrcPony/at93cxx.cpp
+++ b/SrcPony/at93cxx.cpp
@@ -122,13 +122,7 @@ int At93cxx::Verify(int type)
 
 	int size = GetNoOfBank() * GetBankSize();
 	int asize = GetBus()->CalcAddressSize(GetAddrSize());
-	unsigned char *localbuf;
-	localbuf = new unsigned char[size];
-
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
+    unsigned char *localbuf = new unsigned char[size];
 
 	int rval = 1;
 

--- a/SrcPony/at93cxx8.cpp
+++ b/SrcPony/at93cxx8.cpp
@@ -132,11 +132,6 @@ int At93cxx8::Verify(int type)
 	unsigned char *localbuf;
 	localbuf = new unsigned char[size];
 
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
-
 	int rval = 1;
 
 	if (type & PROG_TYPE)

--- a/SrcPony/csmfbuf.cpp
+++ b/SrcPony/csmfbuf.cpp
@@ -205,12 +205,12 @@ int csmFileBuf::Load(int loadtype, long relocation_offfset)
 			}
 		}
 
-		if (okline_counter == 0)
-		{
-			rval = BADFILETYPE;
-		}
-
 		rval = addr;
+
+        if (okline_counter == 0)
+        {
+            rval = BADFILETYPE;
+        }
 	}
 
 	fh.close();

--- a/SrcPony/e2401.cpp
+++ b/SrcPony/e2401.cpp
@@ -166,11 +166,6 @@ int mE2401::Verify(int type)
 	long size = GetSize();
 	unsigned char *localbuf = new unsigned char[size];
 
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
-
 	GetBus()->ReadStart();
 
 	int rval = 1;

--- a/SrcPony/e24xx-2.cpp
+++ b/SrcPony/e24xx-2.cpp
@@ -83,11 +83,6 @@ int E24xx2::Write(int probe, int type)
 	long size = GetSize();
 	unsigned char *localbuf = new unsigned char[writepage_size + 2];
 
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
-
 	int rval = OK;
 
 	if (type & PROG_TYPE)
@@ -210,11 +205,6 @@ int E24xx2::Verify(int type)
 
 	long readpage_size = 256;
 	unsigned char *localbuf = new unsigned char[readpage_size];
-
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
 
 	GetBus()->ReadStart();
 

--- a/SrcPony/e24xx.cpp
+++ b/SrcPony/e24xx.cpp
@@ -196,11 +196,6 @@ int E24xx::Verify(int type)
 
 	unsigned char *localbuf = new unsigned char[GetBankSize()];
 
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
-
 	GetBus()->ReadStart();
 
 	int rval = 1;

--- a/SrcPony/e2awinfo.cpp
+++ b/SrcPony/e2awinfo.cpp
@@ -834,13 +834,7 @@ int e2AppWinInfo::Save()
 {
 	int rval;
 
-	uint8_t *localbuf;
-	localbuf = new uint8_t[GetBufSize()];
-
-	if (localbuf == 0)
-	{
-		return OUTOFMEMORY;
-	}
+    uint8_t *localbuf = new uint8_t[GetBufSize()];
 
 	//save buffer
 	memcpy(localbuf, GetBufPtr(), GetBufSize());

--- a/SrcPony/e2cmdw.cpp
+++ b/SrcPony/e2cmdw.cpp
@@ -244,11 +244,6 @@ e2CmdWindow::e2CmdWindow(QWidget *parent) :
 	{
 		BusIO **b = GetBusVectorPtr();
 
-		if (!b)
-		{
-			exit(-1);
-		}
-
 		awip = new e2AppWinInfo(this, "", b);
 		//              qDebug() << b << a;
 		PostInit(); // removed from e2AppWinInfo
@@ -627,7 +622,7 @@ void e2CmdWindow::setLang(QAction *mnu)
 {
 	QString lngStr;
 	qDebug() << "setLang";
-	mnu = langGroup->checkedAction();
+    //mnu = langGroup->checkedAction();
 
 	lngStr = mnu->text();
 	lngStr = lngStr.remove("&");
@@ -3346,7 +3341,7 @@ int e2CmdWindow::CmdProgram()
 		verbose = verboseErr;        //Disable all ok messages
 	}
 
-	if (result == OK && (prog_opt & RELOAD_YES))
+    if ((prog_opt & RELOAD_YES))
 	{
 		result = CmdReload();
 	}
@@ -3646,8 +3641,7 @@ int e2CmdWindow::CmdRunScript(bool test_mode)
 			continue;
 		}
 
-		QString cmdbuf = lst.at(0);
-		cmdbuf.toUpper();
+        QString cmdbuf = lst.at(0).toUpper();
 
 		if (cmdbuf == "SELECTDEVICE")
 		{
@@ -5512,12 +5506,17 @@ void e2CmdWindow::UpdateStatusBar()
 		return;
 	}
 
-	QString buf;
-	//*** 13/09/99
-	buf.sprintf(STATUSBAR_PRINT, GetDevSize(), awip->GetCRC(), awip->IsBufChanged() ? '*' : ' ');
 
-	lblEEPInfo->setText(buf);
-	lblStringID->setText(!awip ? " " : awip->GetStringID());
+    lblStringID->setText(" ");
+
+    if(awip)
+    {
+        QString buf;
+        buf.sprintf(STATUSBAR_PRINT, GetDevSize(), awip->GetCRC(), awip->IsBufChanged() ? '*' : ' ');
+        lblEEPInfo->setText(buf);
+        lblStringID->setText(awip->GetStringID());
+    }
+
 }
 
 

--- a/SrcPony/e2cmdw.h
+++ b/SrcPony/e2cmdw.h
@@ -130,11 +130,11 @@ class e2CmdWindow : public QMainWindow, public e2App, public Ui::MainWindow
 
 	void SetProgress(int progress = 0);
 
-	int IsAppBusy()
+    bool IsAppBusy()
 	{
 		return (app_status == AppBusy);
 	}
-	int IsAppReady()
+    bool IsAppReady()
 	{
 		return (app_status == AppReady);
 	}
@@ -322,7 +322,7 @@ class e2CmdWindow : public QMainWindow, public e2App, public Ui::MainWindow
 	menuToGroup *searchMenuInDeviceVector(int new_type);
 
 	void createDeviceMenues();
-	void addI2C8Struct();;
+    void addI2C8Struct();
 	void addI2C16Struct();
 	void addI2CAT17Struct();
 	void addMW16Struct();

--- a/SrcPony/e2pfbuf.cpp
+++ b/SrcPony/e2pfbuf.cpp
@@ -100,107 +100,99 @@ int e2pFileBuf::Load(int loadtype, long relocation_offset)
 	if (datastream.readRawData((char *)&hdr, sizeof(e2pHeader)) &&
 			strncmp(hdr.fileID, id_string, E2P_ID_SIZE) == 0)
 	{
-		unsigned char *localbuf;
-		localbuf = new unsigned char[hdr.e2pSize];
+        unsigned char *localbuf = new unsigned char[hdr.e2pSize];
 
-		if (localbuf)
-		{
-			//Controlla il CRC dell'Header
-			if (mcalc_crc(&hdr, sizeof(hdr) - sizeof(hdr.headCrc)) == hdr.headCrc &&
-					//Check for CRC in memory
-					fcalc_crc(fh, sizeof(e2pHeader), 0) == hdr.e2pCrc &&
-					//read buffer
-					datastream.readRawData((char *)localbuf, hdr.e2pSize))
-				//                      fread(FileBuf::GetBufPtr(), hdr.e2pSize, 1, fh) )
-			{
-				SetEEpromType(hdr.e2pType);  //set eeprom device type (and block size too)
-				//FileBuf::SetNoOfBlock( hdr.e2pSize / FileBuf::GetBlockSize() );
+        //Controlla il CRC dell'Header
+        if (mcalc_crc(&hdr, sizeof(hdr) - sizeof(hdr.headCrc)) == hdr.headCrc &&
+                //Check for CRC in memory
+                fcalc_crc(fh, sizeof(e2pHeader), 0) == hdr.e2pCrc &&
+                //read buffer
+                datastream.readRawData((char *)localbuf, hdr.e2pSize))
+            //                      fread(FileBuf::GetBufPtr(), hdr.e2pSize, 1, fh) )
+        {
+            SetEEpromType(hdr.e2pType);  //set eeprom device type (and block size too)
+            //FileBuf::SetNoOfBlock( hdr.e2pSize / FileBuf::GetBlockSize() );
 
-				if (hdr.fversion > 0)
-				{
-					SetLockBits(((uint32_t)hdr.e2pExtLockBits << 8) | hdr.e2pLockBits);
-					SetFuseBits(((uint32_t)hdr.e2pExtFuseBits << 8) | hdr.e2pFuseBits);
-				}
-				else
-				{
-					//Old file version
-					if (GetE2PPriType(hdr.e2pType) == PIC16XX ||
-							GetE2PPriType(hdr.e2pType) == PIC168XX ||
-							GetE2PPriType(hdr.e2pType) == PIC125XX)
-					{
-						SetLockBits(((uint32_t)hdr.e2pLockBits << 8) | hdr.e2pFuseBits);
-					}
-					else
-					{
-						SetLockBits(hdr.e2pLockBits);
-						SetFuseBits(hdr.e2pFuseBits);
-					}
+            if (hdr.fversion > 0)
+            {
+                SetLockBits(((uint32_t)hdr.e2pExtLockBits << 8) | hdr.e2pLockBits);
+                SetFuseBits(((uint32_t)hdr.e2pExtFuseBits << 8) | hdr.e2pFuseBits);
+            }
+            else
+            {
+                //Old file version
+                if (GetE2PPriType(hdr.e2pType) == PIC16XX ||
+                        GetE2PPriType(hdr.e2pType) == PIC168XX ||
+                        GetE2PPriType(hdr.e2pType) == PIC125XX)
+                {
+                    SetLockBits(((uint32_t)hdr.e2pLockBits << 8) | hdr.e2pFuseBits);
+                }
+                else
+                {
+                    SetLockBits(hdr.e2pLockBits);
+                    SetFuseBits(hdr.e2pFuseBits);
+                }
 
-				}
+            }
 
-				if (hdr.fversion > 1)
-				{
-					SetSplitted(((uint32_t)hdr.split_size_High << 16) | hdr.split_size_Low);
-				}
-				else
-				{
-					SetSplitted(hdr.split_size_Low);
-				}
+            if (hdr.fversion > 1)
+            {
+                SetSplitted(((uint32_t)hdr.split_size_High << 16) | hdr.split_size_Low);
+            }
+            else
+            {
+                SetSplitted(hdr.split_size_Low);
+            }
 
-				SetStringID(hdr.e2pStringID);
-				SetComment(hdr.e2pComment);
-				SetRollOver(hdr.flags & 7);
-				SetCRC(hdr.e2pCrc);
+            SetStringID(hdr.e2pStringID);
+            SetComment(hdr.e2pComment);
+            SetRollOver(hdr.flags & 7);
+            SetCRC(hdr.e2pCrc);
 
-				//Copy the content into the buffer
-				if (loadtype == ALL_TYPE)
-				{
-					if (hdr.e2pSize <= GetBufSize())
-					{
-						memcpy(FileBuf::GetBufPtr(), localbuf, hdr.e2pSize);
-					}
-				}
-				else if (loadtype == PROG_TYPE)
-				{
-					long s = GetSplitted();
+            //Copy the content into the buffer
+            if (loadtype == ALL_TYPE)
+            {
+                if (hdr.e2pSize <= GetBufSize())
+                {
+                    memcpy(FileBuf::GetBufPtr(), localbuf, hdr.e2pSize);
+                }
+            }
+            else if (loadtype == PROG_TYPE)
+            {
+                long s = GetSplitted();
 
-					if (s <= 0)
-					{
-						s = hdr.e2pSize;
-					}
+                if (s <= 0)
+                {
+                    s = hdr.e2pSize;
+                }
 
-					//if splittedInfo == 0 then copy ALL
-					if (s <= hdr.e2pSize && s <= GetBufSize())
-					{
-						memcpy(FileBuf::GetBufPtr(), localbuf, s);
-					}
-				}
-				else if (loadtype == DATA_TYPE)
-				{
-					long s = GetSplitted();
+                //if splittedInfo == 0 then copy ALL
+                if (s <= hdr.e2pSize && s <= GetBufSize())
+                {
+                    memcpy(FileBuf::GetBufPtr(), localbuf, s);
+                }
+            }
+            else if (loadtype == DATA_TYPE)
+            {
+                long s = GetSplitted();
 
-					if (s >= 0 &&
-							s < hdr.e2pSize &&
-							hdr.e2pSize <= GetBufSize())
-					{
-						memcpy(FileBuf::GetBufPtr() + s, localbuf + s, hdr.e2pSize - s);
-					}
-				}
+                if (s >= 0 &&
+                        s < hdr.e2pSize &&
+                        hdr.e2pSize <= GetBufSize())
+                {
+                    memcpy(FileBuf::GetBufPtr() + s, localbuf + s, hdr.e2pSize - s);
+                }
+            }
 
-				rval = GetNoOfBlock();
-			}
-			else
-			{
-				rval = READERROR;
-			}
+            rval = GetNoOfBlock();
+        }
+        else
+        {
+            rval = READERROR;
+        }
 
-			delete[] localbuf;
-		}
-		else
-		{
-			rval = OUTOFMEMORY;
-		}
-	}
+        delete[] localbuf;
+    }
 	else
 	{
 		rval = BADFILETYPE;
@@ -229,96 +221,88 @@ int e2pFileBuf::Save(int savetype, long relocation_offset)
 	strncpy(hdr.fileID, id_string, E2P_ID_SIZE);    //Id
 	hdr.e2pSize = FileBuf::GetNoOfBlock() * FileBuf::GetBlockSize();
 
-	unsigned char *localbuf;
-	localbuf = new unsigned char[hdr.e2pSize];
+    unsigned char *localbuf = new unsigned char[hdr.e2pSize];
 
-	if (localbuf)
-	{
-		long s = GetSplitted();
+    long s = GetSplitted();
 
-		memset(localbuf, 0xff, hdr.e2pSize);
+    memset(localbuf, 0xff, hdr.e2pSize);
 
-		if (fh.exists())
-		{
-			if (!fh.open(QIODevice::ReadOnly))
-			{
-				delete[] localbuf;
-				return CREATEERROR;
-			}
-			QDataStream datastream(&fh);
+    if (fh.exists())
+    {
+        if (!fh.open(QIODevice::ReadOnly))
+        {
+            delete[] localbuf;
+            return CREATEERROR;
+        }
+        QDataStream datastream(&fh);
 
-			//Initialize local buffer
-			//  if the file already exist read the current content
-			//  otherwise set the localbuffer to 0xFF
-			if (fh.seek(sizeof(hdr)))
-			{
-				datastream.readRawData((char *)localbuf, hdr.e2pSize);
-			}
-			fh.close();
-		}
+        //Initialize local buffer
+        //  if the file already exist read the current content
+        //  otherwise set the localbuffer to 0xFF
+        if (fh.seek(sizeof(hdr)))
+        {
+            datastream.readRawData((char *)localbuf, hdr.e2pSize);
+        }
+        fh.close();
+    }
 
-		if (savetype == ALL_TYPE)
-		{
-			memcpy(localbuf, FileBuf::GetBufPtr(), hdr.e2pSize);
-		}
-		else if (savetype == DATA_TYPE)
-		{
-			if (hdr.e2pSize > s)
-			{
-				memcpy(localbuf + s, FileBuf::GetBufPtr() + s, hdr.e2pSize - s);
-			}
-		}
-		else if (savetype == PROG_TYPE)
-		{
-			if (s > 0 &&  s <= hdr.e2pSize)
-			{
-				memcpy(localbuf, FileBuf::GetBufPtr(), s);
-			}
-		}
+    if (savetype == ALL_TYPE)
+    {
+        memcpy(localbuf, FileBuf::GetBufPtr(), hdr.e2pSize);
+    }
+    else if (savetype == DATA_TYPE)
+    {
+        if (hdr.e2pSize > s)
+        {
+            memcpy(localbuf + s, FileBuf::GetBufPtr() + s, hdr.e2pSize - s);
+        }
+    }
+    else if (savetype == PROG_TYPE)
+    {
+        if (s > 0 &&  s <= hdr.e2pSize)
+        {
+            memcpy(localbuf, FileBuf::GetBufPtr(), s);
+        }
+    }
 
-		hdr.fversion = E2P_FVERSION;
+    hdr.fversion = E2P_FVERSION;
 
-		hdr.e2pLockBits = (uint8_t)(GetLockBits() & 0xFF);
-		hdr.e2pExtLockBits = (uint16_t)(GetLockBits() >> 8);
-		hdr.e2pFuseBits = (uint8_t)(GetFuseBits() & 0xFF);
-		hdr.e2pExtFuseBits = (uint16_t)(GetFuseBits() >> 8);
+    hdr.e2pLockBits = (uint8_t)(GetLockBits() & 0xFF);
+    hdr.e2pExtLockBits = (uint16_t)(GetLockBits() >> 8);
+    hdr.e2pFuseBits = (uint8_t)(GetFuseBits() & 0xFF);
+    hdr.e2pExtFuseBits = (uint16_t)(GetFuseBits() >> 8);
 
-		hdr.e2pType = GetEEpromType();
-		strncpy(hdr.e2pStringID, GetStringID().toLatin1().constData(), 28);
-		strncpy(hdr.e2pComment, GetComment().toLatin1().constData(), 85);
-		hdr.flags = GetRollOver() & 7;
-		hdr.split_size_Low = (uint16_t)GetSplitted();
-		hdr.split_size_High = (uint16_t)(GetSplitted() >> 16);
-		hdr.e2pCrc = mcalc_crc(localbuf, hdr.e2pSize);
-		hdr.headCrc = mcalc_crc(&hdr, sizeof(hdr) - sizeof(hdr.headCrc));
+    hdr.e2pType = GetEEpromType();
+    strncpy(hdr.e2pStringID, GetStringID().toLatin1().constData(), 28);
+    strncpy(hdr.e2pComment, GetComment().toLatin1().constData(), 85);
+    hdr.flags = GetRollOver() & 7;
+    hdr.split_size_Low = (uint16_t)GetSplitted();
+    hdr.split_size_High = (uint16_t)(GetSplitted() >> 16);
+    hdr.e2pCrc = mcalc_crc(localbuf, hdr.e2pSize);
+    hdr.headCrc = mcalc_crc(&hdr, sizeof(hdr) - sizeof(hdr.headCrc));
 
-		if (fh.open(QIODevice::WriteOnly | QIODevice::Truncate))
-		{
-			QDataStream datastream(&fh);
+    if (fh.open(QIODevice::WriteOnly | QIODevice::Truncate))
+    {
+        QDataStream datastream(&fh);
 
-			//Write to file
-			if (datastream.writeRawData((char *)&hdr, sizeof(hdr)) &&         //Write the header
-					datastream.writeRawData((char *)localbuf, hdr.e2pSize))   //Write the buffer
-			{
-				rval = GetNoOfBlock();
-			}
-			else
-			{
-				rval = WRITEERROR;
-			}
-			fh.close();
-		}
-		else
-		{
-			rval = CREATEERROR;
-		}
+        //Write to file
+        if (datastream.writeRawData((char *)&hdr, sizeof(hdr)) &&         //Write the header
+                datastream.writeRawData((char *)localbuf, hdr.e2pSize))   //Write the buffer
+        {
+            rval = GetNoOfBlock();
+        }
+        else
+        {
+            rval = WRITEERROR;
+        }
+        fh.close();
+    }
+    else
+    {
+        rval = CREATEERROR;
+    }
 
-		delete[] localbuf;
-	}
-	else
-	{
-		rval = OUTOFMEMORY;
-	}
+    delete[] localbuf;
 
-	return rval;
+    return rval;
 }

--- a/SrcPony/microbus.cpp
+++ b/SrcPony/microbus.cpp
@@ -280,7 +280,7 @@ int MicroWireBus::Reset(void)
 }
 
 
-int MicroWireBus::CalcAddressSize(int mem_size, int org) const
+int MicroWireBus::CalcAddressSize(int mem_size) const
 {
 	if (mem_size-- <= 0)
 	{

--- a/SrcPony/microbus.h
+++ b/SrcPony/microbus.h
@@ -36,7 +36,7 @@
 class MicroWireBus : public BusIO
 {
   public:                //------------------------------- public
-	MicroWireBus(BusInterface *ptr = 0);
+    MicroWireBus(BusInterface *ptr = nullptr);
 	virtual ~MicroWireBus();
 
 	//      long Read(int addr, uint8_t *data, long length);
@@ -44,7 +44,7 @@ class MicroWireBus : public BusIO
 
 	int Reset();
 
-	virtual int CalcAddressSize(int mem_size, int org) const;
+    virtual int CalcAddressSize(int mem_size) const;
 
 	void SetDelay();
 

--- a/SrcPony/nvm3060.cpp
+++ b/SrcPony/nvm3060.cpp
@@ -188,13 +188,7 @@ int Nvm3060::Verify(int type)
 
 		GetBus()->UseSecondaryAddress(false);
 
-		unsigned char *localbuf;
-		localbuf = new unsigned char[size];
-
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
+        unsigned char *localbuf = new unsigned char[size];
 
 		rval = GetBus()->Read(start_addr, localbuf, size);
 

--- a/SrcPony/pic125xx.cpp
+++ b/SrcPony/pic125xx.cpp
@@ -160,13 +160,7 @@ int Pic125xx::Verify(int type)
 
 	if (GetSize() >= GetSplitted())
 	{
-		unsigned char *localbuf;
-		localbuf = new unsigned char[GetSize()];
-
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
+        unsigned char *localbuf = new unsigned char[GetSize()];
 
 		int v_prog = OK, v_config = OK;
 

--- a/SrcPony/pic16xx.cpp
+++ b/SrcPony/pic16xx.cpp
@@ -204,13 +204,7 @@ int Pic16xx::Verify(int type)
 
 	if (GetSize() >= GetSplitted())
 	{
-		unsigned char *localbuf;
-		localbuf = new unsigned char[GetSize()];
-
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
+        unsigned char *localbuf = new unsigned char[GetSize()];
 
 		int v_data = OK, v_prog = OK, v_config = OK;
 

--- a/SrcPony/sde2506.cpp
+++ b/SrcPony/sde2506.cpp
@@ -125,13 +125,7 @@ int Sde2506::Verify(int type)
 	if (type & PROG_TYPE)
 	{
 		int size = GetNoOfBank() * GetBankSize();
-		unsigned char *localbuf;
-		localbuf = new unsigned char[size];
-
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
+        unsigned char *localbuf = new unsigned char[size];
 
 		rval = GetBus()->Read(0, localbuf, size);
 

--- a/SrcPony/sdebus.h
+++ b/SrcPony/sdebus.h
@@ -52,7 +52,6 @@ class Sde2506Bus : public BusIO
 	int SendControlBit(int opcode)
 	{
 		return SendDataWord(opcode, 1);
-		WaitUsec(5);
 	}
 	int SendAddress(int addr)
 	{

--- a/SrcPony/x2444.cpp
+++ b/SrcPony/x2444.cpp
@@ -132,11 +132,6 @@ int X2444::Verify(int type)
 		unsigned char *localbuf;
 		localbuf = new unsigned char[size];
 
-		if (localbuf == 0)
-		{
-			return OUTOFMEMORY;
-		}
-
 		rval = GetBus()->Read(0, localbuf, size);
 
 		if (rval != size)

--- a/ponyprog.pro
+++ b/ponyprog.pro
@@ -274,7 +274,7 @@ FORMS    += SrcPony/forms/aboutdlg.ui \
 
 # for next version, when script for ts files convertion is implemented
 #TRANSLATIONS += localization/qtbase_cs.ts 
-	    
+
 # TODO: please check this
 #win32:LIBS += -L$$PWD/windows/
 #win64:LIBS += -L$$PWD/windows/


### PR DESCRIPTION
- Removed unnecessary checkings  if operator new returns null pointer;
- Fixed wrong function At93cBus::CalcAddressSize override;
- at89sbus: init uninitialized members in default constructor
- csmfbuf: I suppose there was a logic error with setting the rval variable (please check this) 

