### PR TITLE
Supress deprecated warning about hex/dec

### DIFF
--- a/SrcPony/at250bus.cpp
+++ b/SrcPony/at250bus.cpp
@@ -137,7 +137,7 @@ int At250Bus::Reset(void)
 
 long At250Bus::Read(int addr, uint8_t *data, long length, int page_size)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << addr << ", " << data << ", " << (dec) << length << ")";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << addr << ", " << data << ", " << (Qt::dec) << length << ")";
 
 	long len;
 

--- a/SrcPony/at250bus2.cpp
+++ b/SrcPony/at250bus2.cpp
@@ -36,12 +36,12 @@
 At250BigBus::At250BigBus(BusInterface *ptr)
 	: At250Bus(ptr)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << ptr << (dec) <<  ")";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << ptr << (Qt::dec) <<  ")";
 }
 
 long At250BigBus::Read(int addr, uint8_t *data, long length, int page_size)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << addr << ", " << data << ", " << (dec) << length << ")";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << addr << ", " << data << ", " << (Qt::dec) << length << ")";
 	ReadStart();
 
 	long len;

--- a/SrcPony/at89sxx.cpp
+++ b/SrcPony/at89sxx.cpp
@@ -96,7 +96,7 @@ int At89sxx::QueryType(long &type)
 	code[0] = GetBus()->ReadDeviceCode(0x30);
 	code[1] = GetBus()->ReadDeviceCode(0x31);
 
-	qDebug() << "At89sxx::ParseID(30) *** " << (hex) << code[0] << " - " << code[1] << (dec);
+	qDebug() << "At89sxx::ParseID(30) *** " << (Qt::hex) << code[0] << " - " << code[1] << (Qt::dec);
 
 	type = 0;
 
@@ -116,7 +116,7 @@ int At89sxx::QueryType(long &type)
 		code[1] = GetBus()->ReadDeviceCode(0x100);
 		code[2] = GetBus()->ReadDeviceCode(0x200);
 
-		qDebug() << "At89sxx::ParseID(100) *** " << (hex) << code[0] << " - " << code[1] << " - " <<  code[2] << (dec);
+		qDebug() << "At89sxx::ParseID(100) *** " << (Qt::hex) << code[0] << " - " << code[1] << " - " <<  code[2] << (Qt::dec);
 
 		if (code[0] == 0x1E && code[1] == 0x51 && code[2] == 0x06)
 		{

--- a/SrcPony/at90sxx.cpp
+++ b/SrcPony/at90sxx.cpp
@@ -366,7 +366,7 @@ int At90sxx::QueryType(long &type)
 	code[1] = GetBus()->ReadDeviceCode(1);
 	code[2] = GetBus()->ReadDeviceCode(2);
 
-	qDebug() << "At90sxx::ParseID() *** " << (hex) << code[0] << " - " << code[1] << " - " << code[2] << (dec);
+	qDebug() << "At90sxx::ParseID() *** " << (Qt::hex) << code[0] << " - " << code[1] << " - " << code[2] << (Qt::dec);
 
 	detected_type = type = 0;
 	detected_signature = "";

--- a/SrcPony/at93cbus.cpp
+++ b/SrcPony/at93cbus.cpp
@@ -114,7 +114,7 @@ long At93cBus::Read(int addr, uint8_t *data, long length, int page_size)
 {
 	(void)page_size;
 
-	qDebug() << "At93cBus::Read(" << (hex) << addr << ", " << data << ", " << (dec) << length;
+	qDebug() << "At93cBus::Read(" << (Qt::hex) << addr << ", " << data << ", " << (Qt::dec) << length;
 
 	ReadStart();
 

--- a/SrcPony/bitfield.cpp
+++ b/SrcPony/bitfield.cpp
@@ -309,7 +309,7 @@ void BitFieldWidget::setMaskBits(const QString &cMask)
 	// at begin of string only
 	mskName = "^" + mskName + "\\d+";
 
-	qDebug() << cMask <<  "converted to" << mskName << (bin) << localField << (dec);
+	qDebug() << cMask <<  "converted to" << mskName << (bin) << localField << (Qt::dec);
 
 	// search in QTreeWidget the names
 	for (idx = 0; idx < treeWidget->topLevelItemCount(); idx++)

--- a/SrcPony/ch341a.cpp
+++ b/SrcPony/ch341a.cpp
@@ -932,7 +932,7 @@ int32_t ch341::SetBaudRate(int32_t speed)
 			dv_mod = (mod + 0xFF) / 0x100;
 
 			// calculated, now send to device
-			qDebug() << "set baudrate" << speed << (hex) << (dv_div << 8) + (dv_prescale) << (uint16_t)(dv_mod) << (dec) ;
+			qDebug() << "set baudrate" << speed << (Qt::hex) << (dv_div << 8) + (dv_prescale) << (uint16_t)(dv_mod) << (Qt::dec) ;
 
 			ret = libusb_control_transfer(devHandle, CTRL_OUT, CH341_REQ_WRITE_REG, CH341_REG_BAUD1, (dv_div << 8) + (dv_prescale), NULL, 0, timeout);
 			if (ret < 0)

--- a/SrcPony/csmfbuf.cpp
+++ b/SrcPony/csmfbuf.cpp
@@ -287,7 +287,7 @@ int csmFileBuf::Save(int savetype, long relocation_offfset)
 			for (addr = 0; addr < size; addr++)
 			{
 				int value = ptr[addr];
-				out << (hex) << addr << " " << value << "\n";
+				out << (Qt::hex) << addr << " " << value << "\n";
 			}
 
 			fh.close();

--- a/SrcPony/e2app.cpp
+++ b/SrcPony/e2app.cpp
@@ -196,7 +196,7 @@ int e2App::OpenPort(int port)
 //=====================>>> e2App::ClosePort <<<==============================
 void e2App::ClosePort()
 {
-	qDebug() << Q_FUNC_INFO << " iniBus=" << (hex) << iniBus << (dec);
+	qDebug() << Q_FUNC_INFO << " iniBus=" << (Qt::hex) << iniBus << (Qt::dec);
 	iniBus->Close();
 }
 
@@ -217,7 +217,7 @@ int e2App::TestPort(int port, bool open_only)
 //=====================>>> e2App::OpenBus <<<==============================
 int e2App::OpenBus(BusIO *p)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << p << (dec) << ")";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << p << (Qt::dec) << ")";
 
 	iniBus->Close();
 
@@ -250,7 +250,7 @@ int e2App::OpenBus(BusIO *p)
 //=====================>>> e2App::SleepBus <<<==============================
 void e2App::SleepBus()
 {
-	qDebug() << Q_FUNC_INFO << " iniBus=" << (hex) << iniBus << (dec);
+	qDebug() << Q_FUNC_INFO << " iniBus=" << (Qt::hex) << iniBus << (Qt::dec);
 
 	busIntp->WaitMsec(5);		// 08/04/98 -- power hold time
 	busIntp->SetPower(false);

--- a/SrcPony/e2cmdw.cpp
+++ b/SrcPony/e2cmdw.cpp
@@ -1316,7 +1316,7 @@ void e2CmdWindow::onSelectChip(QAction *a)
 	currentAct = a;
 	currentAct->setChecked(true);
 
-	qDebug() << Q_FUNC_INFO << "Id: " << (hex) << awip->GetEEPId() << " NewId: " << new_id;
+	qDebug() << Q_FUNC_INFO << "Id: " << (Qt::hex) << awip->GetEEPId() << " NewId: " << new_id;
 
 	if (awip->GetEEPId() != new_id)
 	{
@@ -4460,7 +4460,7 @@ int e2CmdWindow::CmdSetDeviceType(int val)
 	long new_type = CbxIdToType(val, 0);
 	awip->SetEEProm(new_type);
 
-	qDebug() << "CmdSetDeviceType(" << val << "), type=" << (hex) << new_type << (dec);
+	qDebug() << "CmdSetDeviceType(" << val << "), type=" << (Qt::hex) << new_type << (Qt::dec);
 
 	return CmdSelectDevice(new_type);
 }
@@ -4470,7 +4470,7 @@ int e2CmdWindow::CmdSetDeviceSubType(int val)
 	int v1 = cbxEEPType->currentIndex();
 	long new_type = CbxIdToType(v1, val);
 
-	qDebug() << "CmdSetDeviceSubType(" << val << "), v1=" << v1 << ", type=" << (hex) << new_type << (dec);
+	qDebug() << "CmdSetDeviceSubType(" << val << "), v1=" << v1 << ", type=" << (Qt::hex) << new_type << (Qt::dec);
 
 	return CmdSelectDevice(new_type);
 }
@@ -5505,7 +5505,7 @@ void e2CmdWindow::UpdateMenuType(long new_type)
 
 	int new_pritype = GetE2PPriType(new_type);
 
-	qDebug() << Q_FUNC_INFO << " (hex) type:" << (hex) << new_type << " pri:" << new_pritype << (dec);
+	qDebug() << Q_FUNC_INFO << " (Qt::hex) type:" << (Qt::hex) << new_type << " pri:" << new_pritype << (Qt::dec);
 
 	menuToGroup *newMenu = NULL;
 	QAction *newAct = NULL;

--- a/SrcPony/i2cbus.cpp
+++ b/SrcPony/i2cbus.cpp
@@ -299,7 +299,7 @@ long I2CBus::Read(int slave, uint8_t *data, long length, int page_size)
 {
 	long len;
 
-	//qDebug() << Q_FUNC_INFO << "(" << (hex) << slave << "," << (void *)data << "," << (dec) << length << ") - IN";
+	//qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << slave << "," << (void *)data << "," << (Qt::dec) << length << ") - IN";
 	len = StartRead(slave, data, length);
 
 	if (len == length)
@@ -317,7 +317,7 @@ long I2CBus::Write(int slave, uint8_t const *data, long length, int page_size)
 {
 	long len;
 
-	//qDebug() << Q_FUNC_INFO << "(" << (hex) << slave << "," << data << "," << (dec) << length << ") - IN";
+	//qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << slave << "," << data << "," << (Qt::dec) << length << ") - IN";
 
 	len = StartWrite(slave, data, length);
 
@@ -363,7 +363,7 @@ long I2CBus::StartRead(uint8_t slave, uint8_t *data, long length)
 	int temp;
 	long len = length;
 
-	//qDebug() << Q_FUNC_INFO << "(" << (hex) << slave << "," << data << "," << (dec) << length << ") - IN";
+	//qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << slave << "," << data << "," << (Qt::dec) << length << ") - IN";
 
 	if (len > 0)
 	{
@@ -417,7 +417,7 @@ long I2CBus::StartWrite(uint8_t slave, uint8_t const *data, long length)
 	int error;
 	long len = length;
 
-	//qDebug() << Q_FUNC_INFO << "(" << (hex) << slave << "," << data << "," << (dec) << length << ") - IN";
+	//qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << slave << "," << data << "," << (Qt::dec) << length << ") - IN";
 
 	if (len == 0)
 	{
@@ -483,7 +483,7 @@ int I2CBus::Reset(void)
 
 void I2CBus::Close(void)
 {
-	qDebug() << Q_FUNC_INFO << "busI=" << (hex) << busI << (dec);
+	qDebug() << Q_FUNC_INFO << "busI=" << (Qt::hex) << busI << (Qt::dec);
 
 	setSCLSDA();
 	BusIO::Close();

--- a/SrcPony/imbus.cpp
+++ b/SrcPony/imbus.cpp
@@ -296,7 +296,7 @@ int IMBus::Reset(void)
 
 long IMBus::Read(int addr, uint8_t *data, long length, int page_size)
 {
-	qDebug() << "IMBus::Read(" << (hex) << addr << ", " << data << ", " << (dec) <<  length << ")";
+	qDebug() << "IMBus::Read(" << (Qt::hex) << addr << ", " << data << ", " << (Qt::dec) <<  length << ")";
 
 	ReadStart();
 	long len;

--- a/SrcPony/mpsse_interf.cpp
+++ b/SrcPony/mpsse_interf.cpp
@@ -121,7 +121,7 @@ int MpsseInterface::InitPins()
 			return E2ERR_OPENFAILED;
 		}
 
-		qDebug() << Q_FUNC_INFO << (hex)
+		qDebug() << Q_FUNC_INFO << (Qt::hex)
 				 << " Ctrl=" << pin_ctrl
 				 << ", Clock=" << pin_clock << ", ClockIn=" << pin_clockin
 				 << ", DataIn=" << pin_datain << ", DataOut=" << pin_dataout
@@ -218,7 +218,7 @@ int MpsseInterface::SetFrequency(uint32_t freq)
 
 int MpsseInterface::Open(int port)
 {
-	qDebug() << Q_FUNC_INFO << "(" << port << (hex) << usb_vp.vid << ":" << usb_vp.pid << ") IN";
+	qDebug() << Q_FUNC_INFO << "(" << port << (Qt::hex) << usb_vp.vid << ":" << usb_vp.pid << ") IN";
 
 	int ret_val = OK;
 

--- a/SrcPony/pic12bus.cpp
+++ b/SrcPony/pic12bus.cpp
@@ -240,7 +240,7 @@ long Pic12Bus::ReadConfig(uint16_t &data)
 #endif
 	IncAddress(1);
 
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << val << ") OUT";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << val << ") OUT";
 
 	return OK;
 }
@@ -248,7 +248,7 @@ long Pic12Bus::ReadConfig(uint16_t &data)
 
 long Pic12Bus::WriteConfig(uint16_t data)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << data  << ") IN";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << data  << ") IN";
 
 	//      Reset();
 
@@ -312,7 +312,7 @@ long Pic12Bus::Read(int addr, uint8_t *data, long length, int page_size)
 {
 	long len;
 
-	qDebug() << Q_FUNC_INFO << "(" << addr << ", " << (hex) << data << ", " << (dec) <<  length << ") IN";
+	qDebug() << Q_FUNC_INFO << "(" << addr << ", " << (Qt::hex) << data << ", " << (Qt::dec) <<  length << ") IN";
 
 	ReadStart();
 	length >>= 1;   //contatore da byte a word
@@ -359,7 +359,7 @@ long Pic12Bus::Write(int addr, uint8_t const *data, long length, int page_size)
 {
 	long len;
 
-	qDebug() << Q_FUNC_INFO << "(" << addr << ", " << (hex) << data << ", " << (dec) << length << ") IN";
+	qDebug() << Q_FUNC_INFO << "(" << addr << ", " << (Qt::hex) << data << ", " << (Qt::dec) << length << ") IN";
 
 	WriteStart();
 	length >>= 1;   //contatore da byte a word
@@ -411,7 +411,7 @@ int Pic12Bus::WriteProgWord(uint16_t val, long rc_addr)
 	int k;
 	int rval = OK;
 
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << val << ", " << (dec) <<  current_address << ") IN";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << val << ", " << (Qt::dec) <<  current_address << ") IN";
 
 	//Check for RC calibration location
 	if (current_address == rc_addr)
@@ -522,7 +522,7 @@ int Pic12Bus::ProgramPulse(uint16_t val, int verify, int width)
 {
 	int rval = OK;
 
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << val << ", " << (dec) <<  verify << ", " << width << ") IN";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << val << ", " << (Qt::dec) <<  verify << ", " << width << ") IN";
 
 	SendCmdCode(LoadProgCode);
 	SendProgCode(val);

--- a/SrcPony/pic168xx.cpp
+++ b/SrcPony/pic168xx.cpp
@@ -100,7 +100,7 @@ int Pic168xx::QueryType(long &type)
 	{
 		int code = id_locations[6];
 
-		qDebug() << "Pic168xx::ParseID() *** " << (hex) << code << (dec);
+		qDebug() << "Pic168xx::ParseID() *** " << (Qt::hex) << code << (Qt::dec);
 
 		code &= 0x3fe0;         //Strip revision number
 

--- a/SrcPony/ponyioint.cpp
+++ b/SrcPony/ponyioint.cpp
@@ -103,7 +103,7 @@ void PonyIOInterface::SetControlLine(int res)
 			res = !res;
 		}
 
-		qDebug() << "PonyIOInterface::SetControlLine() " << (hex) << lcrOfst  << (dec);
+		qDebug() << "PonyIOInterface::SetControlLine() " << (Qt::hex) << lcrOfst  << (Qt::dec);
 
 #ifdef Q_OS_WIN32
 		if (res)

--- a/SrcPony/portint.cpp
+++ b/SrcPony/portint.cpp
@@ -47,7 +47,7 @@ int PortInterface::IOperm(int a, int b, int c)
 {
 	int retval = -1;
 
-	qDebug() << "PortInterface::IOPerm(" << (hex) << a << ", " << b << ", " << c << (dec) << ")";
+	qDebug() << "PortInterface::IOPerm(" << (Qt::hex) << a << ", " << b << ", " << c << (Qt::dec) << ")";
 
 	if (a + b <= 0x400)     //access to other ports needs iopl(3)
 	{
@@ -180,7 +180,7 @@ PortInterface::~PortInterface()
 
 int PortInterface::InPort(int nport) const
 {
-	qDebug() << "PortInterface::OutPort() ** " << (hex) << first_port << ", " <<  nport << (dec);
+	qDebug() << "PortInterface::OutPort() ** " << (Qt::hex) << first_port << ", " <<  nport << (Qt::dec);
 
 #ifdef Q_OS_WIN32
 	if (gfpInp32 == NULL)
@@ -212,7 +212,7 @@ int PortInterface::InPort(int nport) const
 
 int PortInterface::OutPort(int val, int nport)
 {
-	qDebug() << "PortInterface::OutPort() ** " << (hex) << first_port << ", " << last_port << (dec);
+	qDebug() << "PortInterface::OutPort() ** " << (Qt::hex) << first_port << ", " << last_port << (Qt::dec);
 
 #ifdef Q_OS_WIN32
 	if (gfpOut32 == NULL)
@@ -240,7 +240,7 @@ int PortInterface::OutPort(int val, int nport)
 		cpwreg = val;
 	}
 
-	qDebug() << "PortInterface::outb(" << (hex) << val << ", " << nport << (dec) << ")";
+	qDebug() << "PortInterface::outb(" << (Qt::hex) << val << ", " << nport << (Qt::dec) << ")";
 #ifdef Q_OS_WIN32
 	gfpOut32(nport, val);
 #else
@@ -278,7 +278,7 @@ int PortInterface::OutPortMask(int mask, int val)
 		cpwreg ^= mask;
 	}
 
-	qDebug() << "PortInterface::outb(" << (hex) << cpwreg << ", " << (dec) << write_port << ")";
+	qDebug() << "PortInterface::outb(" << (Qt::hex) << cpwreg << ", " << (Qt::dec) << write_port << ")";
 
 #ifdef Q_OS_WIN32
 	gfpOut32(write_port, cpwreg);
@@ -290,7 +290,7 @@ int PortInterface::OutPortMask(int mask, int val)
 
 int PortInterface::OpenPort(const base_len *ports)
 {
-	qDebug() << "PortInterface::OpenPort(" << (hex) << ports->base << (dec) << ", " << ports->len << ") I";
+	qDebug() << "PortInterface::OpenPort(" << (Qt::hex) << ports->base << (Qt::dec) << ", " << ports->len << ") I";
 
 	int ret_val = E2ERR_OPENFAILED;
 
@@ -679,7 +679,7 @@ static int DetectPortsNT(const QString &ServiceName, const QString &PortFormat, 
 
 	QTextStream out(&fh);
 
-	out << "Enter DetectPortsNT(" << ServiceName << ", " << PortFormat << ", " << (hex) << ports << (dec) << ", " << nports << ")\n";
+	out << "Enter DetectPortsNT(" << ServiceName << ", " << PortFormat << ", " << (Qt::hex) << ports << (Qt::dec) << ", " << nports << ")\n";
 
 	if (ports != 0)
 	{
@@ -763,7 +763,7 @@ static int DetectPortsNT(const QString &ServiceName, const QString &PortFormat, 
 													&& !p[3]                                                        // no high DWORD part
 													&& p[4] >= 8 && p[4] < 16)              // length limited to 16
 											{
-												out << strbuf2 << (dec) << " [0]=" << p[0] << ", [1]=" << p[1] << ", [2]=" << (hex) << p[2] << "h, [3]=" << p[3] << "h, [4]=" << (dec) << p[4] << "\n";
+												out << strbuf2 << (Qt::dec) << " [0]=" << p[0] << ", [1]=" << p[1] << ", [2]=" << (Qt::hex) << p[2] << "h, [3]=" << p[3] << "h, [4]=" << (Qt::dec) << p[4] << "\n";
 
 												if (ports != 0)
 												{

--- a/SrcPony/sdebus.cpp
+++ b/SrcPony/sdebus.cpp
@@ -169,7 +169,7 @@ int Sde2506Bus::Reset(void)
 
 long Sde2506Bus::Read(int addr, uint8_t *data, long length, int page_size)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << addr << ", " << data << ", " << (dec) << length << ")";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << addr << ", " << data << ", " << (Qt::dec) << length << ")";
 	ReadStart();
 
 	long len;

--- a/SrcPony/usbwatcher.cpp
+++ b/SrcPony/usbwatcher.cpp
@@ -43,12 +43,12 @@ static int LIBUSB_CALL hotplug_callback(struct libusb_context *ctx, struct libus
 	if (LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED == event)
 	{
 		w->hotplug_notify(true, desc.idVendor, desc.idProduct);
-		qDebug() << "Connected VID:PID " << (hex) << desc.idVendor << " - " << desc.idProduct;
+		qDebug() << "Connected VID:PID " << (Qt::hex) << desc.idVendor << " - " << desc.idProduct;
 	}
 	else if (LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT == event)
 	{
 		w->hotplug_notify(false, desc.idVendor, desc.idProduct);
-		qDebug() << "Disconnected VID:PID " << (hex) << desc.idVendor << " - " << desc.idProduct;
+		qDebug() << "Disconnected VID:PID " << (Qt::hex) << desc.idVendor << " - " << desc.idProduct;
 	}
 
 	return 0;

--- a/SrcPony/x2444bus.cpp
+++ b/SrcPony/x2444bus.cpp
@@ -62,7 +62,7 @@ void X2444Bus::SendCmdAddr(int cmd, int addr)
 
 long X2444Bus::Read(int addr, uint8_t *data, long length, int page_size)
 {
-	qDebug() << Q_FUNC_INFO << "(" << (hex) << addr << ", " << data << ", " << (dec) << length << ")";
+	qDebug() << Q_FUNC_INFO << "(" << (Qt::hex) << addr << ", " << data << ", " << (Qt::dec) << length << ")";
 	ReadStart();
 
 	long len;


### PR DESCRIPTION
 - Fix several warning like:
 'QTextStream& QTextStreamFunctions::hex(QTextStream&)' is deprecated: Use Qt::hex
 'QTextStream& QTextStreamFunctions::dec(QTextStream&)' is deprecated: Use Qt::dec