### PR TITLE
Bug fix: disable I2C mode when I2CBus is closed

### DIFF
--- a/SrcPony/i2cbus.cpp
+++ b/SrcPony/i2cbus.cpp
@@ -486,6 +486,7 @@ void I2CBus::Close(void)
 	qDebug() << Q_FUNC_INFO << "busI=" << (Qt::hex) << busI << (Qt::dec);
 
 	setSCLSDA();
+	busI->SetI2CMode(false);
 	BusIO::Close();
 }
 


### PR DESCRIPTION
This PR fixes the following issue.

**Issue description**

Hardware: PonyProgFT

Scenario 1:

- open PonyProg
- flash an SPI EEPROM (25xxx)

Result: everything OK, `nEN_BUS` always high.

Scenario 2:

- open PonyProg
- flash an I2C EEPROM (24xxx)
 - flash an SPI EEPROM (25xxx)

Result: issue -> `nEN_BUS` always low during programming.