### PR TITLE
Fix build on FreeBSDFreebsd build fixes

### DIFF
--- a/SrcPony/e2app.cpp
+++ b/SrcPony/e2app.cpp
@@ -25,22 +25,34 @@
 //=========================================================================//
 
 #include "e2profil.h"
+#include <signal.h>
 #include "e2awinfo.h"
+#include <signal.h>
 #include "e2app.h"        // Header file
+#include <signal.h>
 
 #include <QCoreApplication>
+#include <signal.h>
 #include <QString>
+#include <signal.h>
 #include <QtCore>
+#include <signal.h>
 #include <QDebug>
+#include <signal.h>
 
 #ifdef Q_OS_LINUX
 #include <sys/time.h>
+#include <signal.h>
 #include <unistd.h>
+#include <signal.h>
+#include <signal.h>
 #include <signal.h>
 #endif
 
 #include "microbus.h"
+#include <signal.h>
 #include "interfconv.h"
+#include <signal.h>
 
 //const int idAskToSave = 100; // Dummy Command
 

--- a/SrcPony/e2app.cpp
+++ b/SrcPony/e2app.cpp
@@ -25,34 +25,22 @@
 //=========================================================================//
 
 #include "e2profil.h"
-#include <signal.h>
 #include "e2awinfo.h"
-#include <signal.h>
 #include "e2app.h"        // Header file
-#include <signal.h>
 
 #include <QCoreApplication>
-#include <signal.h>
 #include <QString>
-#include <signal.h>
 #include <QtCore>
-#include <signal.h>
 #include <QDebug>
 #include <signal.h>
 
 #ifdef Q_OS_LINUX
 #include <sys/time.h>
-#include <signal.h>
 #include <unistd.h>
-#include <signal.h>
-#include <signal.h>
-#include <signal.h>
 #endif
 
 #include "microbus.h"
-#include <signal.h>
 #include "interfconv.h"
-#include <signal.h>
 
 //const int idAskToSave = 100; // Dummy Command
 

--- a/SrcPony/portint.cpp
+++ b/SrcPony/portint.cpp
@@ -37,43 +37,52 @@
 
 #include "e2cmdw.h"
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && !defined(__FreeBSD__)
 #include <unistd.h>
 
-#if (defined(__x86_64__) || defined(__i386__))	//Qt5 defined(Q_PROCESSOR_X86)
+#if (defined(__x86_64__) || defined(__i386__))
 #include <sys/io.h>
 
 int PortInterface::IOperm(int a, int b, int c)
 {
-	int retval = -1;
+int retval = -1;
 
-	qDebug() << "PortInterface::IOPerm(" << (Qt::hex) << a << ", " << b << ", " << c << (Qt::dec) << ")";
+qDebug() << "PortInterface::IOPerm(" << (Qt::hex) << a << ", " << b << ", " << c << (Qt::dec) << ")";
 
-	if (a + b <= 0x400)     //access to other ports needs iopl(3)
-	{
-		retval = ioperm(a, b, c);
-	}
+if (a + b <= 0x400)
+{
+retval = ioperm(a, b, c);
+}
 
-	qDebug() << "PortInterface::IOPerm() " << retval;
+qDebug() << "PortInterface::IOPerm() " << retval;
 
-	return retval;
+return retval;
 }
 #else
 int PortInterface::IOperm(int a, int b, int c)
 {
-	return -1;
+return -1;
 }
 
 #define outb(x, p)
-#define inb(p)	0
+#define inb(p)0
 #endif
+
+#elif defined(__FreeBSD__)
+#include <sys/types.h>
+#include <machine/cpufunc.h>
+
+int PortInterface::IOperm(int a, int b, int c)
+{
+return 0;
+}
 
 #endif
 
 #ifdef Q_OS_WIN32
 int PortInterface::IOperm(int a, int b, int c)
 {
-	return 0;
+return 0;
 }
 #endif
 

--- a/SrcPony/usbwatcher.h
+++ b/SrcPony/usbwatcher.h
@@ -32,7 +32,7 @@
 #include <QObject>
 #include <QTimer>
 
-#include <libusb-1.0/libusb.h> //Include libsub
+#include <libusb.h> //Include libsub
 
 #include "globals.h"
 


### PR DESCRIPTION
This PR adds the minimum changes required to build PonyProg on FreeBSD.

Changes:
- use the FreeBSD libusb header path;
- include <signal.h> where required;
- add a FreeBSD implementation of PortInterface::IOperm();
- avoid Linux-only ioperm() code on FreeBSD.

Tested on:
- FreeBSD 15.0-RELEASE
- Qt 5.15
- Clang